### PR TITLE
Compile in the input directory rather than home

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ test -z ${cache} && exit
 PROFILE=${HOME}/.profile.d
 
 if [ $BINARY_RELEASES ]; then
-    ROOT=${HOME}/
+    ROOT=${build}/
     NAME=$REL_NAME
     tarball=$NAME-$REL_VSN.tar.gz
     if [ -d ${ROOT}/erts-${ERTS_VSN} ]; then


### PR DESCRIPTION
Make things actually work everywhere.

Without this change, kernel apps work fine, but platform apps build in `$HOME` which is set to `/app/` -- the buildpack and slug actually expect to be built on the input argument for the run, though, which is still `$HOME` for kernel apps, but is a `/tmp/<whatever>` directory on the platform.

This patch therefore uses the BUILD_DIR argument (`$2`) to do things as it is compatible both with the kernel and platform apps.