### PR TITLE
Fix if condition for $RELEASE_UPGRADE

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,7 +65,9 @@ if [ $BINARY_RELEASES ]; then
             mkdir -p ${ROOT}/releases/$REL_VSN/
             cp ${cache}/${tarball} ${ROOT}/releases/$REL_VSN/$NAME.tar.gz
 
-            if [ $RELEASE_UPGRADE = true ]; then
+            ## First default RELEASE_UPGRADE to false, in case it's undefined
+            RELEASE_UPGRADE=${RELEASE_UPGRADE:=false}
+            if [ $RELEASE_UPGRADE == true ]; then
                 ${ROOT}/bin/${NAME} upgrade $REL_VSN
                 tar -xf ${cache}/${tarball} bin
             else


### PR DESCRIPTION
```
if [ $RELEASE_UPGRADE = true ]; then
```

will always throw a

```
./compile: line 68: [: =: unary operator expected
```

when $RELEASE_UPGRADE isn't set.